### PR TITLE
Updating sklearn params

### DIFF
--- a/AWS_Train.ipynb
+++ b/AWS_Train.ipynb
@@ -82,7 +82,9 @@
     "\n",
     "sklearn = SKLearn(\n",
     "    entry_point=script_path,\n",
-    "    train_instance_type=\"ml.m4.xlarge\",\n",
+    "    instance_type=\"ml.m4.xlarge\",\n",
+    "    framework_version=\"0.20.0\",\n",
+    "    py_version=\"py3\",\n",
     "    role=role,\n",
     "    sagemaker_session=sagemaker_session)"
    ]


### PR DESCRIPTION
New versions of SageMaker uses `instance_type` instead of `train_instance_type`. Also, SageMaker requires you to provide a `python version` and `framework version`. I've added those new parameters in `AWS_Train.ipynb`